### PR TITLE
Add Russian localization file and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Auto-detects your Windows system language. Supported:
 - 🇮🇹 Italian
 - 🇩🇪 German
 - 🇫🇷 French
+- 🇷🇺 Russian
 
 *(Falls back to English if system language is not supported)*
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -21,6 +21,7 @@ pub fn get_system_language() -> String {
         "it" => "it".to_string(),
         "de" => "de".to_string(),
         "fr" => "fr".to_string(),
+        "ru" => "ru".to_string(),
         _ => "en".to_string(),
     }
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -382,7 +382,7 @@ export default function Settings() {
                   <option value="it">Italiano</option>
                   <option value="de">Deutsch</option>
                   <option value="fr">Français</option>
-                  <option value="fr">Russian</option>
+                  <option value="ru">Russian</option>
                 </select>
               </div>
               <div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -477,7 +477,7 @@ export default function Settings() {
                 onClick={() =>
                   invoke("open_folder_cmd", { path: "https://ko-fi.com/hsr" })
                 }
-                className="inline-flex items-center gap-2 rounded-xl bg-[#ff5e5b] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[#ff5e5b]/20 hover:bg-[#e05451] hover:shadow-xl hover:shadow-[#e05451]/30 transition-all"
+                className="inline-flex items-center gap-2 rounded-xl bg-[#ff5e5b] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[#ff5e5b]/20 hover:bg-[#e05451] hover:shadow-xl hover:shadow-[#ff5e5b]/30 hover:-translate-y-0.5 transition-all"
               >
                 <Heart size={20} className="fill-white" />
                 Support Mouzi on Ko-fi

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -382,6 +382,7 @@ export default function Settings() {
                   <option value="it">Italiano</option>
                   <option value="de">Deutsch</option>
                   <option value="fr">Français</option>
+                  <option value="fr">Russian</option>
                 </select>
               </div>
               <div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -382,7 +382,7 @@ export default function Settings() {
                   <option value="it">Italiano</option>
                   <option value="de">Deutsch</option>
                   <option value="fr">Français</option>
-                  <option value="ru">Russian</option>
+                  <option value="ru">Русский</option>
                 </select>
               </div>
               <div>
@@ -477,7 +477,7 @@ export default function Settings() {
                 onClick={() =>
                   invoke("open_folder_cmd", { path: "https://ko-fi.com/hsr" })
                 }
-                className="inline-flex items-center gap-2 rounded-xl bg-[#ff5e5b] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[#ff5e5b]/20 hover:bg-[#e05451] hover:shadow-xl hover:shadow-[#ff5e5b]/30 hover:-translate-y-0.5 transition-all"
+                className="inline-flex items-center gap-2 rounded-xl bg-[#ff5e5b] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[#ff5e5b]/20 hover:bg-[#e05451] hover:shadow-xl hover:shadow-[#e05451]/30 transition-all"
               >
                 <Heart size={20} className="fill-white" />
                 Support Mouzi on Ko-fi

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,6 +5,7 @@ import pl from './locales/pl.json';
 import it from './locales/it.json';
 import de from './locales/de.json';
 import fr from './locales/fr.json';
+import ru from './locales/ru.json';
 
 const resources = {
   en: { translation: en },
@@ -12,9 +13,10 @@ const resources = {
   it: { translation: it },
   de: { translation: de },
   fr: { translation: fr },
+  ru: { translation: ru },
 };
 
-export type SupportedLang = 'en' | 'pl' | 'it' | 'de' | 'fr';
+export type SupportedLang = 'en' | 'pl' | 'it' | 'de' | 'fr'| 'ru';
 
 export async function initI18n(lang: SupportedLang) {
   await i18n.use(initReactI18next).init({

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -16,7 +16,7 @@ const resources = {
   ru: { translation: ru },
 };
 
-export type SupportedLang = 'en' | 'pl' | 'it' | 'de' | 'fr'| 'ru';
+export type SupportedLang = 'en' | 'pl' | 'it' | 'de' | 'fr' | 'ru';
 
 export async function initI18n(lang: SupportedLang) {
   await i18n.use(initReactI18next).init({

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1,0 +1,58 @@
+{
+  "app": {
+    "name": "Mouzi",
+    "tagline": "Скачал — забыл, Mouzi всё запомнит"
+  },
+  "popup": {
+    "title": "Mouzi",
+    "cleanNow": "Сортировать сейчас",
+    "openDownloads": "Открыть загрузки",
+    "recentActions": "Недавние действия",
+    "noActions": "Пока нет действий",
+    "weeklyStats": "На этой неделе",
+    "undo": "Отменить",
+    "settings": "Настройки",
+    "quit": "Выход"
+  },
+  "settings": {
+    "title": "Настройки Mouzi",
+    "folders": {
+      "title": "Отслеживаемые папки",
+      "add": "Добавить папку",
+      "remove": "Удалить",
+      "mode": "Режим",
+      "silent": "Тихий",
+      "suggest": "Предлагать"
+    },
+    "rules": {
+      "title": "Правила",
+      "add": "Добавить правило",
+      "edit": "Редактировать",
+      "delete": "Удалить",
+      "name": "Название",
+      "extensions": "Расширения",
+      "destination": "Папка назначения",
+      "pattern": "Шаблон",
+      "priority": "Приоритет",
+      "action": "Действие",
+      "enabled": "Включено"
+    },
+    "history": {
+      "title": "История",
+      "clear": "Очистить историю",
+      "undo": "Отменить",
+      "undone": "Отменено",
+      "empty": "История пуста"
+    },
+    "general": {
+      "title": "Общие",
+      "language": "Язык",
+      "theme": "Тема",
+      "telemetry": "Включить телеметрию",
+      "startWithSystem": "Запускать вместе с системой"
+    }
+  },
+  "notifications": {
+    "cleaned": "Отсортировано: {{count}}"
+  }
+}


### PR DESCRIPTION
Added Russian language support for Mouzi.

Changes

* Added `ru.json` localization file
* Registered Russian locale in the localization index

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Russian localization with system auto-detection and a Русский option in Settings; restores the button hover translate effect. Updates `SupportedLang`, i18n resources, Tauri language detection, and README.

<sup>Written for commit fad96667c52e3cc68e1479eb1e75510299dd56e7. Summary will update on new commits. <a href="https://cubic.dev/pr/hsr88/mouzi/pull/10?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

