### PR TITLE
Add Japanese translation for i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Auto-detects your Windows system language. Supported:
 - 🇩🇪 German
 - 🇫🇷 French
 - 🇷🇺 Russian
+- 🇯🇵 Japanese
 
 *(Falls back to English if system language is not supported)*
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,6 +22,7 @@ pub fn get_system_language() -> String {
         "de" => "de".to_string(),
         "fr" => "fr".to_string(),
         "ru" => "ru".to_string(),
+        "ja" => "ja".to_string(),
         _ => "en".to_string(),
     }
 }

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -53,6 +53,15 @@ impl TrayI18n {
                 strings.insert("settings_title", "Настройки Mouzi");
                 strings.insert("organized", "Организовано {} файл(ов)");
             }
+            "ja" => {
+                strings.insert("quit", "終了");
+                strings.insert("settings", "設定");
+                strings.insert("clean_now", "今すぐ整理");
+                strings.insert("tooltip", "Mouzi");
+                strings.insert("popup_title", "Mouzi");
+                strings.insert("settings_title", "Mouziの設定");
+                strings.insert("organized", "{}個のファイルを整理しました");
+            }
             _ => {
                 strings.insert("quit", "Quit");
                 strings.insert("settings", "Settings");

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -398,6 +398,7 @@ export default function Settings() {
                   <option value="de">Deutsch</option>
                   <option value="fr">Français</option>
                   <option value="ru">Русский</option>
+                  <option value="ja">日本語</option>
                 </select>
               </div>
               <div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -6,6 +6,7 @@ import it from './locales/it.json';
 import de from './locales/de.json';
 import fr from './locales/fr.json';
 import ru from './locales/ru.json';
+import ja from './locales/ja.json';
 
 const resources = {
   en: { translation: en },
@@ -14,9 +15,10 @@ const resources = {
   de: { translation: de },
   fr: { translation: fr },
   ru: { translation: ru },
+  ja: { translation: ja },
 };
 
-export type SupportedLang = 'en' | 'pl' | 'it' | 'de' | 'fr' | 'ru';
+export type SupportedLang = 'en' | 'pl' | 'it' | 'de' | 'fr' | 'ru' | 'ja';
 
 export async function initI18n(lang: SupportedLang) {
   await i18n.use(initReactI18next).init({

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1,0 +1,92 @@
+{
+  "app": {
+    "name": "Mouzi",
+    "tagline": "ダウンロードして、あとは忘れよう – Mouziが覚えています",
+    "loading": "Mouzi..."
+  },
+  "popup": {
+    "title": "Mouzi",
+    "cleanNow": "今すぐ整理",
+    "openDownloads": "ダウンロードフォルダを開く",
+    "recentActions": "最近のアクション",
+    "noActions": "まだアクションがありません",
+    "weeklyStats": "今週",
+    "undo": "元に戻す",
+    "settings": "設定",
+    "quit": "終了",
+    "organized": "整理済み: {{file}}",
+    "openFolder": "クリックして開く → {{folder}}"
+  },
+  "settings": {
+    "title": "Mouziの設定",
+    "folders": {
+      "title": "監視対象フォルダ",
+      "add": "フォルダを追加",
+      "remove": "削除",
+      "mode": "モード",
+      "silent": "サイレント",
+      "suggest": "提案"
+    },
+    "rules": {
+      "title": "ルール",
+      "add": "ルールを追加",
+      "edit": "編集",
+      "delete": "削除",
+      "name": "名前",
+      "extensions": "拡張子",
+      "destination": "移動先",
+      "pattern": "パターン",
+      "priority": "優先順位",
+      "action": "アクション",
+      "enabled": "有効"
+    },
+    "history": {
+      "title": "履歴",
+      "clear": "履歴を削除",
+      "undo": "取り消す",
+      "undone": "取り消し済み",
+      "empty": "履歴がありません",
+      "revertAll": "すべて取り消す"
+    },
+    "general": {
+      "title": "一般",
+      "language": "言語",
+      "theme": "テーマ",
+      "telemetry": "テレメトリを有効化",
+      "startWithSystem": "システムと同時に起動",
+      "gracePeriod": "猶予時間",
+      "gracePeriodDesc": "ファイルが最後に変更されてから移動するまでの待機時間。0にするとすぐに移動します。",
+      "checkFileLock": "ファイルロックの確認",
+      "checkFileLockDesc": "他のプロセスで使用中のファイルをスキップ"
+    },
+    "ignore": {
+      "title": "除外",
+      "rulesTitle": "除外ルール",
+      "description": "監視対象フォルダを選択して、Mouziがスキップするファイルのパターンを設定します。パターンは .mouziignoreファイルとしてフォルダ内に保存されます。",
+      "folder": "フォルダ",
+      "selectFolder": "フォルダを選択...",
+      "patterns": "パターン",
+      "noRules": "まだルールはありません。以下に追加してください。",
+      "placeholder": "例: *.tmp や node_modules/",
+      "add": "追加",
+      "tips": "ヒント:",
+      "save": ".mouziignoreを保存",
+      "saved": "保存しました!",
+      "remove": "削除"
+    },
+    "about": {
+      "tagline": "ダウンロードを、思い通りに。",
+      "description": "Mouziは、システムトレイに常駐する静かで洗練されたファイルオーガナイザーで、ダウンロードフォルダ(およびその他のフォルダ)を自動で整理します。バックグラウンドで静かに動作し、カスタマイズ可能なルールに基づきファイルを移動、名前の変更、または並べ替えます。",
+      "checkUpdates": "アップデートを確認",
+      "support": "Ko-fiでMouziを支援する",
+      "supportDesc": "皆様のご支援により、Mouziは日々進化し続けています。支援していただき、ありがとうございます！ 🙏"
+    }
+  },
+  "notifications": {
+    "cleaned": "{{count}}個のファイルを整理しました"
+  },
+  "common": {
+    "cancel": "キャンセル",
+    "off": "OFF"
+  }
+}


### PR DESCRIPTION
Added Japanese translation and change related files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added full Japanese localization across the app and tray, with auto-detection of `ja`, and updated the README to list Japanese support. Japanese is now selectable in Settings.

- **New Features**
  - Added `ja` locale and translations.
  - Included `ja` in i18n resources and `SupportedLang`.
  - Added 日本語 to the language selector in Settings.
  - Localized tray strings and enabled system language detection for `ja`.

<sup>Written for commit 4da2daa2c9466a9c0e692b0f35486aa99dc26b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

