### PR TITLE
fix: Add missing key "settings.folders.placeholder" for en, it and ja

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -25,7 +25,8 @@
       "remove": "Remove",
       "mode": "Mode",
       "silent": "Silent",
-      "suggest": "Suggest"
+      "suggest": "Suggest",
+      "placeholder": "C:/Users/.../Downloads"
     },
     "rules": {
       "title": "Rules",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -25,7 +25,8 @@
       "remove": "Rimuovi",
       "mode": "Modalità",
       "silent": "Silenzioso",
-      "suggest": "Suggerisci"
+      "suggest": "Suggerisci",
+      "placeholder": "C:/Users/.../Downloads"
     },
     "rules": {
       "title": "Regole",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -25,7 +25,8 @@
       "remove": "削除",
       "mode": "モード",
       "silent": "サイレント",
-      "suggest": "提案"
+      "suggest": "提案",
+      "placeholder": "C:/Users/.../Downloads"
     },
     "rules": {
       "title": "ルール",


### PR DESCRIPTION
Added the missing localized strings for en, it and ja.

this:
<img width="892" height="161" alt="Screenshot" src="https://github.com/user-attachments/assets/62a5364e-3821-4c9e-80af-d3e06bedd807" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing `settings.folders.placeholder` string to the en, it, and ja locales so the Folders input shows a proper example path and i18n warnings stop. This fixes the placeholder appearing as the key or blank in those languages.

<sup>Written for commit 467d0d0555f02334e5d3cd56bce6a27ae4e0007a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

