### PR TITLE
Enhance input styles and fix theme inconsistencies (especially for macOS systems)

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -31,7 +31,7 @@ export default function About() {
             path: "https://mouzi.cc/#download",
           })
         }
-        className="flex w-full items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
+        className="flex w-full items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text hover:bg-border transition-colors"
       >
         <Download size={16} className="text-primary" />
         {t("settings.about.checkUpdates")}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -363,7 +363,7 @@ export default function Settings() {
                       <select
                         value={f.mode || "silent"}
                         onChange={(e) => f.id && updateFolderMode(f.id, e.target.value)}
-                        className="w-full max-w-xs rounded-md border border-border bg-surface px-2 py-1.5 text-sm outline-none focus:border-primary"
+                        className="appearance-none w-full max-w-xs rounded-md border border-border bg-surface px-2 py-1.5 text-sm outline-none focus:border-primary"
                       >
                         <option value="silent">{t("settings.folders.modeSilent")}</option>
                         <option value="manual">{t("settings.folders.modeManual")}</option>
@@ -438,11 +438,10 @@ export default function Settings() {
               </label>
               {ruleToast && (
                 <div
-                  className={`text-xs px-3 py-2 rounded-md ${
-                    ruleToast.type === "success"
-                      ? "bg-green-50 text-green-700 border border-green-200"
-                      : "bg-red-50 text-red-700 border border-red-200"
-                  }`}
+                  className={`text-xs px-3 py-2 rounded-md ${ruleToast.type === "success"
+                    ? "bg-green-50 text-green-700 border border-green-200"
+                    : "bg-red-50 text-red-700 border border-red-200"
+                    }`}
                 >
                   {ruleToast.message}
                 </div>
@@ -609,9 +608,8 @@ export default function Settings() {
                 {logs.map((log) => (
                   <div
                     key={log.id}
-                    className={`flex items-center justify-between rounded-lg border px-4 py-3 ${
-                      log.undone ? "border-border bg-surface-dark opacity-50" : "border-border"
-                    }`}
+                    className={`flex items-center justify-between rounded-lg border px-4 py-3 ${log.undone ? "border-border bg-surface-dark opacity-50" : "border-border"
+                      }`}
                   >
                     <div>
                       <div className="text-sm">{log.file_name}</div>
@@ -670,7 +668,7 @@ export default function Settings() {
                 <select
                   value={settings?.language || "en"}
                   onChange={(e) => handleChangeLanguage(e.target.value)}
-                  className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
+                  className="appearance-none w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
                 >
                   <option value="en">English</option>
                   <option value="pl">Polski</option>
@@ -690,7 +688,7 @@ export default function Settings() {
                   onChange={(e) =>
                     settings && saveSettings({ ...settings, theme: e.target.value })
                   }
-                  className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
+                  className="appearance-none w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
                 >
                   <option value="system">{t("settings.general.themeSystem")}</option>
                   <option value="light">{t("settings.general.themeLight")}</option>
@@ -703,14 +701,12 @@ export default function Settings() {
                 </label>
                 <button
                   onClick={() => setAutostart(!settings?.autostart)}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    settings?.autostart ? "bg-primary" : "bg-surface-dark"
-                  }`}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings?.autostart ? "bg-primary" : "bg-surface-dark"
+                    }`}
                 >
                   <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      settings?.autostart ? "translate-x-6" : "translate-x-1"
-                    }`}
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings?.autostart ? "translate-x-6" : "translate-x-1"
+                      }`}
                   />
                 </button>
               </div>
@@ -732,7 +728,7 @@ export default function Settings() {
                   step={1}
                   value={sliderIndex}
                   onChange={(e) => handleGraceSliderChange(parseInt(e.target.value, 10))}
-                  className="w-full accent-primary"
+                  className="w-full"
                 />
                 <div className="flex items-center gap-2">
                   <input
@@ -749,7 +745,7 @@ export default function Settings() {
                     onChange={(e) =>
                       handleGraceNumberChange(graceValue, e.target.value as GraceUnit)
                     }
-                    className="rounded-md border border-border bg-surface px-2 py-1.5 text-sm outline-none focus:border-primary"
+                    className="appearance-none rounded-md border border-border bg-surface px-2 py-1.5 text-sm outline-none focus:border-primary"
                   >
                     <option value="seconds">{t("settings.general.gracePeriodSeconds")}</option>
                     <option value="minutes">{t("settings.general.gracePeriodMinutes")}</option>
@@ -780,14 +776,12 @@ export default function Settings() {
                     const updated = { ...settings, lock_check_enabled: !settings.lock_check_enabled };
                     saveSettings(updated);
                   }}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    settings?.lock_check_enabled ? "bg-primary" : "bg-surface-dark"
-                  }`}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings?.lock_check_enabled ? "bg-primary" : "bg-surface-dark"
+                    }`}
                 >
                   <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      settings?.lock_check_enabled ? "translate-x-6" : "translate-x-1"
-                    }`}
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings?.lock_check_enabled ? "translate-x-6" : "translate-x-1"
+                      }`}
                   />
                 </button>
               </div>
@@ -807,14 +801,12 @@ export default function Settings() {
                 </label>
                 <button
                   onClick={() => handleScheduleChange({ schedule_enabled: !localSchedule.schedule_enabled })}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    localSchedule.schedule_enabled ? "bg-primary" : "bg-surface-dark"
-                  }`}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${localSchedule.schedule_enabled ? "bg-primary" : "bg-surface-dark"
+                    }`}
                 >
                   <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      localSchedule.schedule_enabled ? "translate-x-6" : "translate-x-1"
-                    }`}
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${localSchedule.schedule_enabled ? "translate-x-6" : "translate-x-1"
+                      }`}
                   />
                 </button>
               </div>
@@ -828,7 +820,7 @@ export default function Settings() {
                   onChange={(e) =>
                     handleScheduleChange({ schedule_times_per_day: parseInt(e.target.value, 10) })
                   }
-                  className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
+                  className="appearance-none w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
                 >
                   <option value={1}>{t("settings.scheduler.once")}</option>
                   <option value={2}>{t("settings.scheduler.twice")}</option>
@@ -941,7 +933,7 @@ function IgnoreTab() {
         <select
           value={selectedFolder}
           onChange={(e) => setSelectedFolder(e.target.value)}
-          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
+          className="appearance-none w-full rounded-md border border-border bg-surface px-3 py-2 text-sm outline-none focus:border-primary"
         >
           <option value="">{t("settings.ignore.selectFolder")}</option>
           {folders.map((f) => (
@@ -1037,11 +1029,10 @@ function SidebarButton({
   return (
     <button
       onClick={onClick}
-      className={`w-full flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-        active
-          ? "bg-primary/10 text-primary"
-          : "text-text-muted hover:bg-border hover:text-text"
-      }`}
+      className={`w-full flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${active
+        ? "bg-primary/10 text-primary"
+        : "text-text-muted hover:bg-border hover:text-text"
+        }`}
     >
       {icon}
       {label}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -984,7 +984,7 @@ function IgnoreTab() {
             <button
               onClick={handleAdd}
               disabled={!newPattern.trim()}
-              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-bg hover:bg-primary/90 disabled:opacity-40 transition-colors"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-hover disabled:opacity-40 transition-colors"
             >
               {t("settings.ignore.add")}
             </button>
@@ -1004,7 +1004,7 @@ function IgnoreTab() {
 
           <button
             onClick={handleSave}
-            className="flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-bg hover:bg-primary/90 transition-colors"
+            className="flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-hover transition-colors"
           >
             <Save size={16} />
             {saved ? t("settings.ignore.saved") : t("settings.ignore.save")}

--- a/src/index.css
+++ b/src/index.css
@@ -30,7 +30,9 @@
   --color-text-muted-val: #8a7e75;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
   margin: 0;
   font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
@@ -39,4 +41,66 @@ html, body, #root {
 
 body {
   background: transparent;
+}
+
+select {
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%238c7f70' viewBox='0 0 16 16'%3E%3Cpath d='M4.646 5.646a.5.5 0 0 1 .708 0L8 8.293l2.646-2.647a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  background-size: 1rem;
+  padding-right: 2rem;
+}
+
+.dark select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%238a7e75' viewBox='0 0 16 16'%3E%3Cpath d='M4.646 5.646a.5.5 0 0 1 .708 0L8 8.293l2.646-2.647a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E");
+}
+
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  height: 1.5rem;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--color-border-val);
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-primary-val);
+  border: 2px solid white;
+  margin-top: -6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+input[type="range"]:focus-visible::-webkit-slider-thumb {
+  transform: scale(1.15);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary-val) 30%, transparent);
+}
+
+input[type="range"]::-moz-range-track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--color-border-val);
+  border: none;
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-primary-val);
+  border: 2px solid white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -104,3 +104,33 @@ input[type="range"]::-moz-range-thumb {
   border: 2px solid white;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
+
+input[type="checkbox"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 4px;
+  border: 1.5px solid var(--color-border-val);
+  background: var(--color-surface-val);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+input[type="checkbox"]:checked {
+  background: var(--color-primary-val);
+  border-color: var(--color-primary-val);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='white' viewBox='0 0 16 16'%3E%3Cpath d='M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 0.75rem;
+}
+
+input[type="checkbox"]:focus-visible {
+  outline: 2px solid var(--color-primary-val);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
**Before:**
<img width="1012" height="762" alt="Captura de pantalla 2026-06-19 a la(s) 9 52 06 p m" src="https://github.com/user-attachments/assets/14c548dd-6e12-4469-ba7d-bd481cd589f4" />

**After:**
<img width="1012" height="762" alt="Captura de pantalla 2026-06-19 a la(s) 9 51 33 p m" src="https://github.com/user-attachments/assets/66192852-6ba9-41f5-8f26-9295cb86ddb6" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies input styles (selects, sliders, checkboxes) and fixes theme inconsistencies, especially on macOS. Buttons and hover states now use consistent colors and accessible focus rings.

- **Bug Fixes**
  - Standardized `select`, `range`, and `checkbox` with custom CSS: `appearance: none`, themed arrow/track/thumb, and visible focus rings for accessibility.
  - Replaced undefined `bg-surface-hover` with `bg-border`; updated primary buttons to `text-white` with `hover:bg-primary-hover`.
  - Applied `appearance-none` to all `select` elements in Settings/Ignore; removed `accent-primary` from range for consistent theming.

<sup>Written for commit 6a9edcafd364b1253ebdf033cbb2ab6044b5d403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

