### PR TITLE
fix: disable DMABuf renderer on Linux to fix Wayland protocol error

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,14 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Work around WebKitGTK DMABuf renderer bug on Wayland.
+    // Without this, GTK window creation fails with:
+    //   "Error 71 (Protocol error) dispatching to Wayland display."
+    // Upstream: https://bugs.webkit.org/show_bug.cgi?id=280210
+    //           https://github.com/tauri-apps/tauri/issues/10702
+    #[cfg(target_os = "linux")]
+    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
     mouzi_lib::run()
 }


### PR DESCRIPTION
Set WEBKIT_DISABLE_DMABUF_RENDERER=1 on Linux before GTK/WebKit initialization to work around a webkit2gtk DMABuf renderer bug that causes "Error 71 (Protocol error) dispatching to Wayland display" when creating windows from the system tray.

Closes #42

Upstream bugs:
- https://bugs.webkit.org/show_bug.cgi?id=280210
- https://github.com/tauri-apps/tauri/issues/10702

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the WebKitGTK DMABuf renderer on Linux to prevent Wayland protocol errors when opening windows from the system tray. This sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` before GTK/WebKit initialization if the variable is not already set.

<sup>Written for commit 4bc8b280518c5983cb93f56fd4c5ad03bedfc495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

