### PR TITLE
Update Vietnamese translation to version 0.1.4

### DIFF
--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -40,6 +40,16 @@
       "modePaused": "Tạm dừng",
       "modeDesc": "Chọn cách Mouzi xử lý các tệp trong thư mục này."
     },
+    "archive": {
+      "title": "Nhập kho lưu trữ",
+      "description": "Chọn một kho lưu trữ Google Takeout .zip, .tgz, hoặc .tar.gz. Mouzi sẽ giải nén nó, sắp xếp các tên lồng trùng nhau một cách an toàn và thực hiện các quy tắc của bạn.",
+      "import": "Nhập kho lưu trữ",
+      "importing": "Đang nhập kho lưu trữ...",
+      "importingShort": "Đang nhập...",
+      "importSuccess": "Đã giải nén {{extracted}} tệp và sắp xếp {{count}} tệp.",
+      "importError": "Không thể nhập kho lưu trữ: {{error}}",
+      "openImportFolder": "Mở thư mục nhập"
+    },
     "rules": {
       "title": "Quy tắc",
       "add": "Thêm quy tắc",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Vietnamese locale to v0.1.4 by adding translations for the archive import flow (Google Takeout .zip/.tgz/.tar.gz).
Includes title/description, import actions and progress, success/error messages, and the “open import folder” label.

<sup>Written for commit 2f606d579483fc732fd8043e7212cad1c547f5f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

