### PR TITLE
Hide macOS app from dock on first launch

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 use tauri::Manager;
 use tauri_plugin_autostart::ManagerExt;
 use watcher::FolderWatcher;
+use tauri::ActivationPolicy;
 
 pub struct AppState {
     pub watcher: Arc<Mutex<FolderWatcher>>,
@@ -78,6 +79,10 @@ pub fn run() {
             scheduler: scheduler::Scheduler::new(),
         })
         .setup(|app| {
+            // Hid app from dock on macOS
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(ActivationPolicy::Accessory);
+
             let app_handle = app.handle().clone();
 
             // Initialize database

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,12 @@ pub fn run() {
                             .args(["/c", "start", "", &path])
                             .spawn();
                     }
+                    #[cfg(target_os = "macos")]
+                    {
+                        let _ = std::process::Command::new("open")
+                            .arg(&path)
+                            .spawn();
+                    }
                     #[cfg(not(target_os = "windows"))]
                     {
                         let _ = std::process::Command::new("xdg-open")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,7 +58,7 @@ pub fn run() {
                             .arg(&path)
                             .spawn();
                     }
-                    #[cfg(not(target_os = "windows"))]
+                    #[cfg(target_os = "linux")]
                     {
                         let _ = std::process::Command::new("xdg-open")
                             .arg(&path)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,9 @@
       "nsis": {
         "installerHooks": "./installer.nsh"
       }
+    },
+    "macOS": {
+      "infoPlist": "Info.plist"
     }
   }
 }


### PR DESCRIPTION
This is as with any other daemon app, such as Docker Desktop, etc. The app runs mainly in the menubar, yet the app appears. This can be fixed by a few small fixes in the app's code, and the app will only show in the menubar and not hang around in the Dock infinitely as long as the app is running

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the macOS app from the Dock so it only lives in the menu bar. Prevents the Dock icon from lingering and fixes path opening on macOS and Linux.

- **Bug Fixes**
  - macOS: Run as UIElement (`LSUIElement=true`) and set `tauri` activation policy to Accessory.
  - Point `tauri.conf.json` to the custom Info.plist.
  - Path launching: use `open` on macOS; run `xdg-open` only on Linux.

<sup>Written for commit 24058a48c1bf4bbdfd25dd6af26c802dd40818f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

