### PR TITLE
Add some more archive & image file types/extensions

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -246,7 +246,7 @@ pub fn insert_default_rules(_folder_path: &str) -> SqliteResult<()> {
     }
 
     let defaults = vec![
-        ("Images", 1, vec!["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg", "ico"], "Images"),
+        ("Images", 1, vec!["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg", "ico", "heic", "heif"], "Images"),
         ("Documents", 2, vec!["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "rtf", "odt"], "Documents"),
         ("Archives", 3, vec!["zip", "rar", "7z", "tar", "gz", "bz2"], "Archives"),
         ("Installers", 4, vec!["exe", "msi", "msix", "appx"], "Installers"),

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -248,7 +248,7 @@ pub fn insert_default_rules(_folder_path: &str) -> SqliteResult<()> {
     let defaults = vec![
         ("Images", 1, vec!["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg", "ico", "heic", "heif"], "Images"),
         ("Documents", 2, vec!["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "rtf", "odt"], "Documents"),
-        ("Archives", 3, vec!["zip", "rar", "7z", "tar", "gz", "bz2", "xz", "tar"], "Archives"),
+        ("Archives", 3, vec!["zip", "rar", "7z", "tar", "gz", "bz2", "xz"], "Archives"),
         ("Installers", 4, vec!["exe", "msi", "msix", "appx"], "Installers"),
         ("Music", 5, vec!["mp3", "wav", "flac", "aac", "ogg", "wma", "m4a"], "Music"),
         ("Videos", 6, vec!["mp4", "avi", "mkv", "mov", "wmv", "flv", "webm"], "Videos"),

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -248,7 +248,7 @@ pub fn insert_default_rules(_folder_path: &str) -> SqliteResult<()> {
     let defaults = vec![
         ("Images", 1, vec!["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg", "ico", "heic", "heif"], "Images"),
         ("Documents", 2, vec!["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "rtf", "odt"], "Documents"),
-        ("Archives", 3, vec!["zip", "rar", "7z", "tar", "gz", "bz2"], "Archives"),
+        ("Archives", 3, vec!["zip", "rar", "7z", "tar", "gz", "bz2", "xz", "tar"], "Archives"),
         ("Installers", 4, vec!["exe", "msi", "msix", "appx"], "Installers"),
         ("Music", 5, vec!["mp3", "wav", "flac", "aac", "ogg", "wma", "m4a"], "Music"),
         ("Videos", 6, vec!["mp4", "avi", "mkv", "mov", "wmv", "flv", "webm"], "Videos"),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Recognize HEIC/HEIF images and XZ/TAR archives in default file-type rules. Files with `heic`/`heif` go to Images; `xz`/`tar` to Archives; removed a duplicate `tar` entry.

<sup>Written for commit 1d8b32c95eb2d8955ac195b36598cea84c539fe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

