### PR TITLE
feat(rules): add quick enable toggle

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -649,7 +649,7 @@ export default function Settings() {
                       type="button"
                       role="switch"
                       aria-checked={r.enabled}
-                      aria-label={`${r.name}: ${t("settings.rules.enabled")}`}
+                      aria-label={`${r.name}: ${r.enabled ? t("settings.rules.enabled") : t("common.off")}`}
                       onClick={() => updateRule({ ...r, enabled: !r.enabled })}
                       className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${r.enabled ? "bg-primary" : "bg-border"
                         }`}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -646,6 +646,20 @@ export default function Settings() {
                   </div>
                   <div className="flex items-center gap-1">
                     <button
+                      type="button"
+                      role="switch"
+                      aria-checked={r.enabled}
+                      aria-label={`${r.name}: ${t("settings.rules.enabled")}`}
+                      onClick={() => updateRule({ ...r, enabled: !r.enabled })}
+                      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${r.enabled ? "bg-primary" : "bg-border"
+                        }`}
+                    >
+                      <span
+                        className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${r.enabled ? "translate-x-5" : "translate-x-1"
+                          }`}
+                      />
+                    </button>
+                    <button
                       onClick={() => setEditingRule({ ...r })}
                       className="p-1.5 rounded-md hover:bg-border text-text-muted"
                     >


### PR DESCRIPTION
## Summary

Add a compact enable/disable switch to each rule card so rules can be paused or restored without opening the edit form.

The switch uses the existing `Rule.enabled` state and `updateRule` persistence path. It exposes native switch semantics through `role="switch"` and `aria-checked`, includes a rule-specific accessible label, and leaves the existing edit and delete actions unchanged.

Related to #52 (item 7). This PR intentionally does not close the umbrella issue.

## Validation

- `npm.cmd ci`
- `npm.cmd run build` (TypeScript and Vite production build)
- Exercised the actual Zustand/Tauri update path with a mocked bridge; verified the disabled payload, rule reload, and resulting store state
- Verified switch accessibility wiring and preserved edit/delete handlers
- `git diff --check`

The repository has no test or lint script, so no new test framework was introduced for this UI binding. A Tauri window was not launched for visual testing; the production build and persisted state path were validated directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a quick enable/disable toggle on each rule card so you can pause or restore a rule without opening the edit form. The toggle includes an accessible label that reflects its current state.

- **New Features**
  - Uses `Rule.enabled` with `updateRule` for persistence.
  - Accessible switch semantics (`role="switch"`, `aria-checked`) with a per-rule label that reflects on/off state.
  - Keeps existing edit and delete actions unchanged.

<sup>Written for commit 8d27d336c420cba8d34e4c166b9213f88ad3cc42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

