### PR TITLE
Allow inline comments in mouziignores

### DIFF
--- a/src-tauri/src/ignore.rs
+++ b/src-tauri/src/ignore.rs
@@ -41,7 +41,7 @@ pub fn save_mouziignore(folder_path: &str, patterns: &[String]) -> Result<(), St
     let path = Path::new(folder_path).join(".mouziignore");
     let mut content = String::from("# Mouzi ignore rules\n# https://mouzi.cc/docs\n\n");
     for p in patterns {
-        content.push_str(p);
+        content.push_str(&p.replace('#', r"\#"));
         content.push('\n');
     }
     fs::write(&path, content).map_err(|e| e.to_string())

--- a/src-tauri/src/ignore.rs
+++ b/src-tauri/src/ignore.rs
@@ -10,9 +10,26 @@ pub fn load_mouziignore(folder_path: &str) -> Vec<String> {
     match fs::read_to_string(&path) {
         Ok(content) => content
             .lines()
-            .map(|l| l.trim())
+            .map(|l| {
+                let l = l.trim();
+                let mut escaped = false;
+                let mut end = l.len();
+
+                for (i, c) in l.char_indices() {
+                    match c {
+                        '\\' => escaped = !escaped,
+                        '#' if !escaped => {
+                            end = i;
+                            break;
+                        }
+                        _ => escaped = false,
+                    }
+                }
+
+                l[..end].trim().to_string()
+            })
             .filter(|l| !l.is_empty() && !l.starts_with('#'))
-            .map(|l| l.to_string())
+            .map(|l| l.replace(r"\#", "#"))
             .collect(),
         Err(_) => Vec::new(),
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable inline comments in `mouziignore` files. Unescaped `#` starts a comment; use `\#` to keep a literal hash in patterns.

- **New Features**
  - Strip text after the first unescaped `#`; full-line comments still ignored.
  - Load: unescape `\#` to `#`. Save: escape `#` in UI-entered patterns so hashes stay literal in `.mouziignore`.

<sup>Written for commit 45708fdb50c480429b831a2462a31985b6e36989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

