### PR TITLE
Add a destination folder picker to rule editor

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -183,6 +183,23 @@ export default function Settings() {
     setEditingRule(null);
   };
 
+  const handlePickRuleDestination = async () => {
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+      });
+      const path = Array.isArray(selected) ? selected[0] : selected;
+      if (path) {
+        setEditingRule((current) =>
+          current ? { ...current, destination: path } : current
+        );
+      }
+    } catch (e) {
+      console.error("Selecting a rule destination failed:", e);
+    }
+  };
+
   const handleChangeLanguage = async (lang: string) => {
     if (!settings) return;
     await i18n.changeLanguage(lang);
@@ -578,11 +595,22 @@ export default function Settings() {
                   </div>
                   <div>
                     <label className="text-xs font-medium text-text-muted">{t("settings.rules.destination")}</label>
-                    <input
-                      value={editingRule.destination}
-                      onChange={(e) => setEditingRule({ ...editingRule, destination: e.target.value })}
-                      className="mt-1 w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm outline-none focus:border-primary"
-                    />
+                    <div className="mt-1 flex gap-2">
+                      <input
+                        value={editingRule.destination}
+                        onChange={(e) => setEditingRule({ ...editingRule, destination: e.target.value })}
+                        className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-sm outline-none focus:border-primary"
+                      />
+                      <button
+                        type="button"
+                        onClick={handlePickRuleDestination}
+                        aria-label={t("settings.rules.selectDestination")}
+                        title={t("settings.rules.selectDestination")}
+                        className="rounded-md border border-border px-2 text-text-muted hover:bg-surface hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                      >
+                        <FolderOpen size={16} aria-hidden="true" />
+                      </button>
+                    </div>
                   </div>
                   <div>
                     <label className="text-xs font-medium text-text-muted">{t("settings.rules.priority")}</label>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -52,6 +52,7 @@
       "name": "Name",
       "extensions": "Erweiterungen",
       "destination": "Ziel",
+      "selectDestination": "Zielordner auswählen",
       "pattern": "Pattern",
       "priority": "Priorität",
       "action": "Aktion",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -52,6 +52,7 @@
       "name": "Name",
       "extensions": "Extensions",
       "destination": "Destination",
+      "selectDestination": "Select destination folder",
       "pattern": "Pattern",
       "priority": "Priority",
       "action": "Action",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -42,6 +42,7 @@
       "name": "Nombre",
       "extensions": "Extensiones",
       "destination": "Destino",
+      "selectDestination": "Seleccionar carpeta de destino",
       "pattern": "Patrón",
       "priority": "Prioridad",
       "action": "Acción",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -52,6 +52,7 @@
       "name": "Nom",
       "extensions": "Extensions",
       "destination": "Destination",
+      "selectDestination": "Sélectionner le dossier de destination",
       "pattern": "Pattern",
       "priority": "Priorité",
       "action": "Action",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -52,6 +52,7 @@
       "name": "Nome",
       "extensions": "Estensioni",
       "destination": "Destinazione",
+      "selectDestination": "Seleziona cartella di destinazione",
       "pattern": "Pattern (regex)",
       "priority": "Priorità",
       "action": "Azione",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -52,6 +52,7 @@
       "name": "名前",
       "extensions": "拡張子",
       "destination": "移動先",
+      "selectDestination": "移動先フォルダーを選択",
       "pattern": "パターン",
       "priority": "優先順位",
       "action": "アクション",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -52,6 +52,7 @@
       "name": "Nazwa",
       "extensions": "Rozszerzenia",
       "destination": "Cel",
+      "selectDestination": "Wybierz folder docelowy",
       "pattern": "Wzorzec (regex)",
       "priority": "Priorytet",
       "action": "Akcja",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -52,6 +52,7 @@
       "name": "Название",
       "extensions": "Расширения",
       "destination": "Папка назначения",
+      "selectDestination": "Выбрать папку назначения",
       "pattern": "Pattern",
       "priority": "Приоритет",
       "action": "Действие",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -52,6 +52,7 @@
       "name": "Назва",
       "extensions": "Розширення",
       "destination": "Цільова тека",
+      "selectDestination": "Вибрати цільову теку",
       "pattern": "Шаблон назви",
       "priority": "Пріоритет",
       "action": "Дія",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -58,6 +58,7 @@
       "name": "Tên",
       "extensions": "Đuôi tệp",
       "destination": "Đích đến",
+      "selectDestination": "Chọn thư mục đích",
       "pattern": "Mẫu",
       "priority": "Độ ưu tiên",
       "action": "Hành động",


### PR DESCRIPTION
## Summary

- add a native folder picker beside the rule destination field
- keep manual destination entry unchanged and preserve it when the dialog is cancelled
- localize the picker's accessible label across all supported locales

## Validation

- `npm run build`
- parsed every locale JSON file
- `git diff --check`

The repository's Rust formatting check currently reports existing drift in untouched files, and Rust tests could not link locally because MSVC `link.exe` is unavailable. No Rust files are changed here.

Refs #52

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native destination folder picker to the rule editor to make setting destinations faster and reduce input errors. Manual entry is unchanged and preserved on cancel, addressing #52.

- **New Features**
  - Adds a button next to the destination input that opens the OS folder picker and updates the field on selection.
  - Adds `settings.rules.selectDestination` to all locales for the button’s accessible label.

<sup>Written for commit 9b3014a1b10e974d069f5b1253f590d692fa7cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hsr88/mouzi/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

